### PR TITLE
Add deployed-at annotation to Deployment template

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -13,10 +13,11 @@ spec:
       {{- include "pgbouncer.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
+        deployedAt: {{ now | quote }}
       labels:
         {{- include "pgbouncer.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
- This will help with redeployments. Currently if you change pgbouncer configs that do not cause the deployment to change, no new pods will be created